### PR TITLE
Fixed overflow:hidden bug in VToggle

### DIFF
--- a/src/components/VToggle/VToggle.vue
+++ b/src/components/VToggle/VToggle.vue
@@ -1,30 +1,30 @@
 <template>
-  <div class="vts-toggle" :class="{ 'vts-toggle--open': isOpen }">
+  <div class="vts-toggle"
+:class="{ 'vts-toggle--open': isOpen }">
     <button
       :id="`${id}-label`"
       ref="label"
       :disabled="disabled"
       :aria-controls="`${id}-content`"
       :aria-expanded="isOpen"
-      @click="isOpen = !isOpen"
       class="vts-toggle__button"
+      @click="isOpen = !isOpen"
     >
       <!-- @slot The content that goes inside the button -->
       <slot name="label" />
     </button>
 
     <transition
-      @before-enter="collapse"
-      @enter="expand"
-      @after-enter="resetHeight"
-      @before-leave="expand"
-      @leave="collapse"
+      name="expand"
+      @enter="enter"
+      @after-enter="afterEnter"
+      @leave="leave"
     >
       <div
+        v-show="isOpen && !disabled"
         :id="`${id}-content`"
         :aria-labelledby="`${id}-label`"
         :aria-hidden="!isOpen"
-        v-show="isOpen && !disabled"
         role="region"
         class="vts-toggle__content"
       >
@@ -36,10 +36,12 @@
 </template>
 
 <script>
+import smoothHeight from '../../mixins/smoothHeight';
 /**
  * Toggle the visibility of content. Useful for something like an FAQ page, for example. Includes ARIA attributes for expandable content and is keyboard friendly.
  */
 export default {
+  mixins: [smoothHeight],
   props: {
     /**
      * The content inside the toggle button
@@ -72,28 +74,18 @@ export default {
       )
     }
   },
-
-  methods: {
-    collapse(el) {
-      el.style.height = 0
-    },
-
-    expand(el) {
-      el.style.height = el.scrollHeight + "px"
-      // Force repaint to make sure the animation is triggered correctly.
-      el.scrollHeight
-    },
-
-    resetHeight(el) {
-      el.style.height = null
-    }
-  }
 }
 </script>
 
 <style>
-.vts-toggle__content {
+.expand-enter-active,
+.expand-leave-active {
   overflow: hidden;
-  transition: height 300ms ease;
+  transition: height 0.2s linear;
+}
+
+.expand-enter,
+.expand-leave-to {
+  height: 0;
 }
 </style>

--- a/src/mixins/smoothHeight.js
+++ b/src/mixins/smoothHeight.js
@@ -1,0 +1,42 @@
+export default {
+  methods: {
+    enter(element) {
+      element.style.position = "absolute"
+      element.style.height = "auto"
+
+      const { height } = getComputedStyle(element)
+
+      element.style.position = null
+      element.style.height = 0
+
+      // Force repaint to make sure the
+      // animation is triggered correctly.
+      getComputedStyle(element).height
+
+      // Trigger the animation.
+      // We use `setTimeout` because we need
+      // to make sure the browser has finished
+      // painting after setting the `height`
+      // to `0` in the line above.
+      setTimeout(() => {
+        element.style.height = height
+      })
+    },
+    afterEnter(element) {
+      element.style.height = "auto"
+    },
+    leave(element) {
+      const { height } = getComputedStyle(element)
+
+      element.style.height = height
+
+      // Force repaint to make sure the
+      // animation is triggered correctly.
+      getComputedStyle(element).height
+
+      setTimeout(() => {
+        element.style.height = 0
+      })
+    },
+  },
+}


### PR DESCRIPTION
Implemented from this article with some additional fixes (so it works in IE11 for example):
https://markus.oberlehner.net/blog/transition-to-height-auto-with-vue/

Better way of using a smooth transition height without the hardcoded `overflow: hidden;`, which I found was causing a bug where elements that you typically want outside of the element (e.g. dropdowns) would be hidden.

I made the method into a mixin, in case you want this used on other things. If not, just remove the mixin and put the method inside the `VToggle.vue` component.