### PR TITLE
Use only user styles if provided.

### DIFF
--- a/src/components/VDialog/VDialog.vue
+++ b/src/components/VDialog/VDialog.vue
@@ -2,7 +2,7 @@
   <transition :name="bgTransition">
     <div
       v-if="showing"
-      :class="['vts-dialog', classes.root]"
+      :class="classes.root ? classes.root : 'vts-dialog'"
       @click="onClick"
       @keydown="onKeydown"
     >
@@ -11,7 +11,7 @@
           :is="tag"
           ref="content"
           :style="{ width: width, maxWidth: maxWidth }"
-          :class="['vts-dialog__content', classes.content]"
+          :class="classes.root ? classes.content : 'vts-dialog__content'"
           tabindex="-1"
           role="dialog"
         >

--- a/src/components/VDialog/VDialog.vue
+++ b/src/components/VDialog/VDialog.vue
@@ -11,7 +11,7 @@
           :is="tag"
           ref="content"
           :style="{ width: width, maxWidth: maxWidth }"
-          :class="classes.root ? classes.content : 'vts-dialog__content'"
+          :class="classes.content ? classes.content : 'vts-dialog__content'"
           tabindex="-1"
           role="dialog"
         >


### PR DESCRIPTION
This is an example of what it might look like to overwrite default styling *if* the user provides styles to the `:classes` prop.