### PR TITLE
Adjustment to row in VTable

### DIFF
--- a/src/components/VTable/VTable.vue
+++ b/src/components/VTable/VTable.vue
@@ -75,7 +75,7 @@
         </thead>
         <tbody>
           <slot v-bind="{ items: cItems, ...$data, perPage }">
-            <tr v-for="(item, index) in cItems" :key="item.id" @click="$emit('click:row', item)">
+            <tr tabindex="0" v-for="(item, index) in cItems" :key="item.id" @click="$emit('click:row', item.original)">
               <slot
                 v-for="(value, key) in item.data"
                 :name="items[index].id ? `row.${items[index].id}` : null"

--- a/src/components/VTable/VTable.vue
+++ b/src/components/VTable/VTable.vue
@@ -75,7 +75,7 @@
         </thead>
         <tbody>
           <slot v-bind="{ items: cItems, ...$data, perPage }">
-            <tr tabindex="0" v-for="(item, index) in cItems" :key="item.id" @click="$emit('click:row', item.original)">
+            <tr v-for="(item, index) in cItems" :key="item.id" @click="$emit('click:row', item.original)">
               <slot
                 v-for="(value, key) in item.data"
                 :name="items[index].id ? `row.${items[index].id}` : null"


### PR DESCRIPTION
Added a tabindex to the row.

Also, adjusted what click:row emitted to item.original. This way the user won't have to dig into original themselves (I imagine that most users will not want to choose between original and data to get what they need).