### PR TITLE
Don’t allow ESC key to dismiss VDialog when dismissible prop set to false

### DIFF
--- a/src/components/VDialog/VDialog.vue
+++ b/src/components/VDialog/VDialog.vue
@@ -134,7 +134,7 @@ export default {
       }
     },
     onKeydown(event) {
-      if (event.keyCode === KEYCODES.ESC) {
+      if (event.keyCode === KEYCODES.ESC && this.dismissible) {
         this.localShow = false;
       }
       if (event.keyCode === KEYCODES.TAB) {


### PR DESCRIPTION
I noticed that regardless of the "dismissible" property setting, pressing the ESC key would dismiss it anyway. This should fix that issue. I'm really enjoying this library overall! 🍻 