### PR TITLE
[issue][94] Use :value and @input instead of v-model on select

### DIFF
--- a/src/components/VInput/VInput.vue
+++ b/src/components/VInput/VInput.vue
@@ -49,7 +49,7 @@
         :checked="localValue === undefined ? $attrs.checked : localValue"
         v-bind="bind"
         @change="localValue = $event.target.checked"
-        @blur.once.once="dirty = true"
+        @blur.once="dirty = true"
         v-on="$listeners"
       />
       <span :class="['vts-input__text', classes.text]">
@@ -69,7 +69,8 @@
       <select
         v-if="'select' === $attrs.type"
         ref="input"
-        v-model="localValue"
+        :value="localValue"
+        @input.prevent="localValue = $event.target.value"
         v-bind="bind"
         @blur.once="dirty = true"
         v-on="$listeners"


### PR DESCRIPTION
Closes #94 

Changes:
- Stop using `v-model` on select inputs
- Manually bind the `localValue` and use the `@input` listener