### PR TITLE
npm ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -28,7 +28,7 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install modules
-        run: npm i
+        run: npm ci
 
       - name: Audit
         run: npm run audit


### PR DESCRIPTION
`npm i` is short for `npm install` which will check for versions like `^1.3.0` and then see that there is a newer version and isntall `1.3.1` and update the `package-lock.json`. However, if there is a bug in `1.3.1` that breaks something in your code/tests/lint/build/whatever, then your build may fail while your local works fine, which can be confusing. If you use `npm ci` then it will no check for newer versions of dependencies or update the `package-lock.json`. Instead it will look at the `package-lock.json` as the source of truth and download those exact version numbers. So ideally the automated `ci` will match exactly what you have installed locally.