### PR TITLE
ie11 support for select

### DIFF
--- a/src/components/VInput/VInput.vue
+++ b/src/components/VInput/VInput.vue
@@ -72,6 +72,7 @@
         :value="localValue"
         v-bind="bind"
         @input="localValue = $event.target.value"
+        @change="localValue = $event.target.value"
         @blur.once="dirty = true"
         v-on="$listeners"
       >


### PR DESCRIPTION
IE11 does not fire the `input` event on `select` html elements. See [this discussion](https://github.com/vuejs/vue/issues/4701) from the Vue repo