### PR TITLE
Moving so can target with sibling selectpor

### DIFF
--- a/src/components/VInput/VInput.vue
+++ b/src/components/VInput/VInput.vue
@@ -62,10 +62,6 @@
       :for="`${id}__input`"
       :class="['vts-input__label', classes.label]"
     >
-      <span :class="['vts-input__text', classes.text]">
-        {{ label }}
-      </span>
-
       <select
         v-if="'select' === $attrs.type"
         ref="input"
@@ -104,6 +100,10 @@
         @blur.once="dirty = true"
         v-on="listeners"
       />
+
+      <span :class="['vts-input__text', classes.text]">
+        {{ label }}
+      </span>
     </label>
 
     <div


### PR DESCRIPTION
Moving the `<span>` so it can be targeted with CSS. This works for `radio`, `checkbox` and `textarea` currently but not the other input types. Eg;

```
  .vts-input__input:focus {
      ~ .vts-input__text::after { color: red; }
    }
```