### PR TITLE
Fixing `name` attribute for radio button

### DIFF
--- a/src/components/VInput/VInput.vue
+++ b/src/components/VInput/VInput.vue
@@ -242,7 +242,6 @@ export default {
         item = typeof item === 'object' ? item : { value: item };
         return Object.assign(item, $attrs, {
           label: item.label || item.value,
-          name: $attrs.name || id,
           value: item.value,
           checked:
             localValue !== undefined ? item.value === localValue : item.checked,


### PR DESCRIPTION
![Screenshot 2021-09-24 at 18 16 52](https://user-images.githubusercontent.com/5795894/134715594-b37d2fd5-99dc-4dda-9741-e13d8ff1c608.png)

* Radio buttons `name` attribute was being overwritten inside of `computedOptions()`. 
* It also meant that `<option>` had the `name` attribute being added to them

By removing create `name` property from inside of `computedOptions()` I believe it fixes both of these things so now you can pass down your own value for `name`