### PR TITLE
feat: add localization of VDate buttons

### DIFF
--- a/docs/components/Date.md
+++ b/docs/components/Date.md
@@ -106,6 +106,58 @@ export default {
 </template>
 ```
 
+## Localization
+
+```vue live
+<template>
+  <VDate
+    :days-of-week="daysOfWeek"
+    :month-labels="monthLabels"
+    :button-labels="buttonLabels"
+  />
+</template>
+
+<script>
+export default {
+  data: () => ({
+    daysOfWeek: Object.freeze({
+      Dim: 'Dimanche',
+      Lun: 'Lundi',
+      Mar: 'Mardi',
+      Mer: 'Mercredi',
+      Jeu: 'Jeudi',
+      Ven: 'Vendredi',
+      Sam: 'Samedi',
+    }),
+
+    monthLabels: [
+      'Janvier',
+      'Février',
+      'Mars',
+      'Avril',
+      'Mai',
+      'Juin',
+      'Juillet',
+      'Août',
+      'Septembre',
+      'Octobre',
+      'Novembre',
+      'Décembre',
+    ],
+
+    buttonLabels: Object.freeze({
+      selectDate: 'Sélectionner la date',
+      showCalendar: 'montrer le calendrier',
+      previousMonth: 'mois précédent',
+      nextMonth: 'mois suivant',
+      previousYear: 'année précédente',
+      nextYear: 'année suivante',
+    })
+  }),
+}
+</script>
+```
+
 
 
 <!-- ## Custom Classes

--- a/src/components/VDate/VDate.vue
+++ b/src/components/VDate/VDate.vue
@@ -7,7 +7,7 @@
         :class="['vtd-date__toggle', classes.toggle]"
         v-on="toggle.on"
       >
-        <span role="img" aria-label="show calendar">&#x1F4C5;</span>
+        <span role="img" :aria-label="buttonLabels.showCalendar">&#x1F4C5;</span>
       </button>
     </slot>
 
@@ -27,7 +27,7 @@
       <div class="vts-date__navigation">
         <button
           :class="['vtd-date__prev-year', classes.prevYear]"
-          aria-label="previous year"
+          :aria-label="buttonLabels.previousYear"
           type="button"
           :disabled="disableNav.prevYear"
           @click="incrementYearBy(-1)"
@@ -38,7 +38,7 @@
         </button>
         <button
           :class="['vtd-date__prev-month', classes.prevMonth]"
-          aria-label="previous month"
+          :aria-label="buttonLabels.previousMonth"
           type="button"
           :disabled="disableNav.prevMonth"
           @click="incrementMonthBy(-1)"
@@ -56,7 +56,7 @@
         </h4>
         <button
           :class="['vtd-date__next-month', classes.nextMonth]"
-          aria-label="next month"
+          :aria-label="buttonLabels.nextMonth"
           type="button"
           :disabled="disableNav.nextMonth"
           @click="incrementMonthBy(1)"
@@ -67,7 +67,7 @@
         </button>
         <button
           :class="['vtd-date__next-year', classes.nextYear]"
-          aria-label="next year"
+          :aria-label="buttonLabels.nextYear"
           type="button"
           :disabled="disableNav.nextYear"
           @click="incrementYearBy(1)"
@@ -258,6 +258,20 @@ export default {
       ],
     },
 
+    buttonLabels: {
+      type: Object,
+      default: () => {
+        return Object.freeze({
+          selectDate: 'Select Date',
+          showCalendar: 'show calendar',
+          previousMonth: 'previous month',
+          nextMonth: 'next month',
+          previousYear: 'previous year',
+          nextYear: 'next year',
+        });
+      },
+    },
+
     classes: {
       type: Object,
       default: () => ({}),
@@ -348,7 +362,7 @@ export default {
       const { show } = this;
       return {
         bind: {
-          'aria-label': 'Select Date',
+          'aria-label': this.buttonLabels.selectDate,
           'aria-expanded': '' + show,
         },
         on: {


### PR DESCRIPTION
fixes #134 

I had several ESLint errors from lines not edited in this PR, I can fix them in another PR in you want me to:

<details>
<summary>ESLint errors and warnings</summary>

    ✖ eslint --fix src:

    /src/components/VDate/VDate.vue
    10:65  error    Replace `>&#x1F4C5;</span` with `⏎··········>&#x1F4C5;</span⏎········`  prettier/prettier
    35:38  error    Replace `⏎&#8606;⏎` with `·&#8606;·`                                    prettier/prettier
    36:1   warning  Expected indentation of 12 spaces but found 0 spaces                    vue/html-indent
    37:1   warning  Expected indentation of 10 spaces but found 0 spaces                    vue/html-indent
    46:39  error    Replace `⏎&#8592;⏎` with `·&#8592;·`                                    prettier/prettier
    47:1   warning  Expected indentation of 12 spaces but found 0 spaces                    vue/html-indent
    48:1   warning  Expected indentation of 10 spaces but found 0 spaces                    vue/html-indent
    64:39  error    Replace `⏎&#8594;⏎` with `·&#8594;·`                                    prettier/prettier
    65:1   warning  Expected indentation of 12 spaces but found 0 spaces                    vue/html-indent
    66:1   warning  Expected indentation of 10 spaces but found 0 spaces                    vue/html-indent
    75:38  error    Replace `⏎&#8608;⏎` with `·&#8608;·`                                    prettier/prettier
    76:1   warning  Expected indentation of 12 spaces but found 0 spaces                    vue/html-indent
    77:1   warning  Expected indentation of 10 spaces but found 0 spaces                    vue/html-indent

    /src/composables/useForm.js
    51:0  warning  Missing JSDoc @property "validate" description  jsdoc/require-property-description

    ✖ 14 problems (5 errors, 9 warnings)
    5 errors and 8 warnings potentially fixable with the `--fix` option.

</details>