### PR TITLE
Prevent accidental form submission

### DIFF
--- a/src/components/VAlert/VAlert.vue
+++ b/src/components/VAlert/VAlert.vue
@@ -14,6 +14,7 @@
         :aria-label="dismissLabel"
         :class="['vts-alert__dismiss', classes.dismiss]"
         @click="dismiss"
+        type="button"
       >
         <!-- @slot The dismiss button content -->
         <slot name="dismiss">&times;</slot>


### PR DESCRIPTION
When the component is nested into a `<form>` the button is considered as `type="submit"` by default.
Forcing `type="button"` allows preventing the form submission.